### PR TITLE
Rev quickdraw to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "quickdraw-dom",
+  "name": "@hulu/quickdraw",
   "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -3860,7 +3860,8 @@
                 "console-control-strings": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "gauge": {
                   "version": "2.6.0",
@@ -3901,6 +3902,7 @@
                       "version": "1.0.2",
                       "bundled": true,
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3911,6 +3913,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
                           },
@@ -3918,7 +3921,8 @@
                             "number-is-nan": {
                               "version": "1.0.0",
                               "bundled": true,
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
@@ -3926,6 +3930,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
                           },
@@ -3933,7 +3938,8 @@
                             "number-is-nan": {
                               "version": "1.0.0",
                               "bundled": true,
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "A MVVM data binding framework designed for speed and efficiency on living room devices",
   "author": "Hulu Living Room",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "quickdraw-dom",
+  "name": "@hulu/quickdraw",
   "version": "0.11.0",
   "description": "A MVVM data binding framework designed for speed and efficiency on living room devices",
   "author": "Hulu Living Room",


### PR DESCRIPTION
This PR bumps Quickdraw to 1.0.0, and changes the package.json name to reflect the npm package naming

The main motivation behind this is versions `^0.x` won't pick up minor version updates (more info here: https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004), which can be annoying to deal with if we want to make updates to this library. 

Also npm best practices suggest when releasing a new package to start off at version 1.0.0