### PR TITLE
Refactor getNodePath and add information to bindingHandler exceptions 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A MVVM data binding framework designed for speed and efficiency on living room devices",
   "author": "Hulu Living Room",
   "scripts": {

--- a/src/base/binding.coffee
+++ b/src/base/binding.coffee
@@ -64,24 +64,11 @@ qdInternal.binding = {
             # pass the real dom node to the binding function as the $element value
             return bindingFunction(bindingContext, qdInternal.dom.unwrap(domNode))
         catch err
-            nodePath = @_getNodePath(domNode)
             error = new QuickdrawError("'#{err.message}' in binding '#{domNode.getAttribute(qd.getConfig('bindingAttribute'))}'", err)
             error.setBindingContext(bindingContext)
-            error.setNodePath(nodePath)
+            error.setDomNode(domNode)
             qdInternal.errors.throw(error)
             return null
-
-    # Gets the tagName and className for all nodes in the parent chain of this VirtualDomNode
-    # @param [VirtualDomNode] domNode the node to calculate the parent chain of
-    # @return [String] the parent chain of the provide domNode
-    _getNodePath : (domNode) ->
-        nodePath = []
-        while domNode?
-            id = domNode.getProperty('id') && "##{domNode.getProperty('id')}"
-            className = domNode.getProperty('className') && ".#{domNode.getProperty('className').replace(" ", ".")}"
-            nodePath.push("#{domNode.getProperty('tagName').toLowerCase()}#{id}#{className}")
-            domNode = domNode.getParentNode()
-        return nodePath.reverse()
 
     # Applies a recursive binding with the given binding context
     # @note this should not be called from outside of quickdraw or a

--- a/src/base/dom.coffee
+++ b/src/base/dom.coffee
@@ -16,7 +16,7 @@ qdInternal.dom = {
     # Takes the given dom tree and constructs a virtualized wrapper around
     # it that can be traversed for bindings. This wrapper is used to allow
     # bindings to quickly compute the updates they wish to apply and transparently
-    # apply changes to the dom nodes only after all bindings have been 
+    # apply changes to the dom nodes only after all bindings have been
     # evaluated
     virtualize: (domNode) ->
         # if the given node is a virtual node just return it
@@ -37,6 +37,19 @@ qdInternal.dom = {
     importNode: (document, node, deep = true) ->
         virtualNode = qdInternal.dom.virtualize(node)
         return virtualNode.cloneNode(deep, document)
+
+    # Gets the tagName and className for all nodes in the parent chain of this VirtualDomNode
+    # @param [DomNode] domNode the node to calculate the parent chain of
+    # @return [String] the parent chain of the provide domNode
+    getNodePath : (domNode) ->
+        nodePath = []
+        while domNode?
+            domNode = @virtualize(domNode)
+            id = domNode.getProperty('id') && "##{domNode.getProperty('id')}"
+            className = domNode.getProperty('className') && ".#{domNode.getProperty('className').replace(" ", ".")}"
+            nodePath.push("#{domNode.getProperty('tagName').toLowerCase()}#{id}#{className}")
+            domNode = domNode.getParentNode()
+        return nodePath.reverse()
 
     # A virtual dom node that wraps a real dom node allowing for changes
     # to the dom node to be staged together before actually being made to
@@ -191,10 +204,10 @@ qdInternal.dom = {
         clearValues: ->
             # clear the storage
             qdInternal.storage.clearValues(@_state.rawNode)
-            
+
             # add this virtual node back to the dom node, only a dispose should disassociate it
             qdInternal.storage.setInternalValue(@_state.rawNode, 'virtual', @)
-            
+
             return
 
         # @param [String] name the name of the property to return
@@ -305,7 +318,7 @@ qdInternal.dom = {
 
             virtualChild = qdInternal.dom.virtualize(child)
             index = @_changes.children.indexOf(virtualChild)
-            
+
             # error if the given child is not a child of this node
             if index is -1
                 return qdInternal.errors.throw(new QuickdrawError("Given element is not a child of this node"))

--- a/src/base/errors.coffee
+++ b/src/base/errors.coffee
@@ -52,6 +52,7 @@ qdInternal.errors.QuickdrawError = class QuickdrawError
     # @param [DomNode] domNode in use during the error
     setDomNode: (domNode) ->
         @_current.domNode = qdInternal.dom.unwrap(domNode)
+        @setNodePath(qdInternal.dom.getNodePath(domNode))
         return
 
     # Set the observable that caused this error (if applicable)

--- a/src/base/handlers.coffee
+++ b/src/base/handlers.coffee
@@ -58,7 +58,15 @@ qd.registerBindingHandler = (keyword, handler, follows = [], override = false) -
                 try
                     result = callback.apply(qdInternal, args)
                 catch err
-                    qdInternal.errors.throw(new QuickdrawError("Error in '#{type}' of '#{keyword}' binding handler: \"#{err.message}\"", err))
+                    # these two handlers pass the node as the second argument
+                    if type in ['initialize', 'update']
+                        node = args[1]
+                    # cleanup passes the node as the only argument
+                    else
+                        node = args[0]
+                    error = new QuickdrawError("Error in '#{type}' of '#{keyword}' binding handler: \"#{err.message}\"", err)
+                    error.setDomNode(node)
+                    qdInternal.errors.throw(error)
                 finally
                     # restore the previous state before this function call
                     stateMemento()

--- a/test/base/binding.coffee
+++ b/test/base/binding.coffee
@@ -63,11 +63,9 @@ describe("Quickdraw.Internal.Binding", ->
             )
 
             errorSpy = sandbox.qd._.errors.throw = sinon.spy()
-            nodePathSpy = sandbox.qd._.binding._getNodePath = sinon.spy()
 
             assert.isNull(sandbox.qd._.binding.getEvaluatedBindingObject(virtualNode, bindingContext), "Should return null if an error is thrown")
 
-            assert.isTrue(nodePathSpy.called, "Should have called _getNodePath")
             assert.isTrue(errorSpy.called, "Should have thrown an error through quickdraw error class")
         )
 
@@ -77,32 +75,6 @@ describe("Quickdraw.Internal.Binding", ->
             functionSpy = sinon.stub(sandbox.qd._.binding, "getBindingFunction", -> return -> fakeBindingObject)
 
             assert.equal(sandbox.qd._.binding.getEvaluatedBindingObject({}, {}), fakeBindingObject, "Should correctly return binding object")
-        )
-    )
-
-    describe("_getNodePath(domNode)", ->
-        it("returns an array of tagNames, ids and classNames of nodes in top-down order", ->
-            rawParentNode = sandbox.document.createElement('div')
-            rawParentNode.id = "id"
-            virtualParentNode = sandbox.qd._.dom.virtualize(rawParentNode)
-
-            rawChildNode = sandbox.document.createElement('div')
-            rawChildNode.className = "child"
-            rawChildNode.id = "childId"
-            virtualChildNode = virtualParentNode.appendChild(rawChildNode)
-
-            rawGrandChildNode = sandbox.document.createElement('div')
-            rawGrandChildNode.className = "grandChild"
-            virtualGrandChildNode = virtualChildNode.appendChild(rawGrandChildNode)
-
-            assert.deepEqual(sandbox.qd._.binding._getNodePath(virtualGrandChildNode), ['div#id', 'div#childId.child', 'div.grandChild'])
-        )
-
-        it("returns information about the node if it doesn't have any parents", ->
-            rawNode = sandbox.document.createElement('div')
-            virtualNode = sandbox.qd._.dom.virtualize(rawNode)
-
-            assert.deepEqual(sandbox.qd._.binding._getNodePath(virtualNode), ['div'])
         )
     )
 
@@ -163,7 +135,7 @@ describe("Quickdraw.Internal.Binding", ->
 
         it("Errors when view model has changed during binding", ->
             vm = sandbox.qd._.models.create({})
-            node = {}
+            node = sandbox.document.createElement('div')
             context = {}
             errorSpy = sinon.stub(sandbox.qd._.errors, "throw")
 

--- a/test/base/dom.coffee
+++ b/test/base/dom.coffee
@@ -36,6 +36,32 @@ describe("Quickdraw.Internal.Dom", ->
         )
     )
 
+    describe("getNodePath(domNode)", ->
+        it("returns an array of tagNames, ids and classNames of nodes in top-down order", ->
+            rawParentNode = sandbox.document.createElement('div')
+            rawParentNode.id = "id"
+            virtualParentNode = sandbox.qd._.dom.virtualize(rawParentNode)
+
+            rawChildNode = sandbox.document.createElement('div')
+            rawChildNode.className = "child"
+            rawChildNode.id = "childId"
+            virtualChildNode = virtualParentNode.appendChild(rawChildNode)
+
+            rawGrandChildNode = sandbox.document.createElement('div')
+            rawGrandChildNode.className = "grandChild"
+            virtualGrandChildNode = virtualChildNode.appendChild(rawGrandChildNode)
+
+            assert.deepEqual(sandbox.qd._.dom.getNodePath(virtualGrandChildNode), ['div#id', 'div#childId.child', 'div.grandChild'])
+        )
+
+        it("returns information about the node if it doesn't have any parents", ->
+            rawNode = sandbox.document.createElement('div')
+            virtualNode = sandbox.qd._.dom.virtualize(rawNode)
+
+            assert.deepEqual(sandbox.qd._.dom.getNodePath(virtualNode), ['div'])
+        )
+    )
+
     describe("VirtualDomNode", ->
         describe("constructor(domNode, parentNode)", ->
             it("A given dom node is correctly wrapped", ->
@@ -498,7 +524,7 @@ describe("Quickdraw.Internal.Dom", ->
                 properties = {}
                 attributes = {}
                 styles = {}
-                
+
                 virtual = new sandbox.qd._.dom.VirtualDomNode(node)
                 virtual._state.hasModifications = true
                 virtual._changes = {


### PR DESCRIPTION
This PR serves as both a refactor to the `getNodePath` function introduced in #1, and also adding the node path to errors thrown by the binding handlers. 

Now, the `getNodePath` is a method on dom.coffee, and is invoked whenever `setDomNode` is set on the QuickdrawError.