### PR TITLE
chore(deps): Switch to public npm for all dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+; always use the public registry for this repo!
+registry = "https://registry.npmjs.com/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,19 +6,19 @@
   "dependencies": {
     "abab": {
       "version": "1.0.4",
-      "resolved": "http://npm.prod.hulu.com/abab/-/abab-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/abab/-/abab-1.0.4.tgz",
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
     "acorn": {
       "version": "2.7.0",
-      "resolved": "http://npm.prod.hulu.com/acorn/-/acorn-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.com/acorn/-/acorn-2.7.0.tgz",
       "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
       "dev": true
     },
     "acorn-globals": {
       "version": "1.0.9",
-      "resolved": "http://npm.prod.hulu.com/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.com/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
       "requires": {
@@ -27,7 +27,7 @@
     },
     "ajv": {
       "version": "6.9.2",
-      "resolved": "http://npm.prod.hulu.com/ajv/-/ajv-6.9.2.tgz",
+      "resolved": "https://registry.npmjs.com/ajv/-/ajv-6.9.2.tgz",
       "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
       "dev": true,
       "requires": {
@@ -61,7 +61,7 @@
     },
     "ansi-cyan": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
       "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
       "dev": true,
       "requires": {
@@ -70,7 +70,7 @@
     },
     "ansi-gray": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
       "dev": true,
       "requires": {
@@ -79,7 +79,7 @@
     },
     "ansi-red": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/ansi-red/-/ansi-red-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/ansi-red/-/ansi-red-0.1.1.tgz",
       "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
       "dev": true,
       "requires": {
@@ -88,31 +88,31 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://npm.prod.hulu.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "http://npm.prod.hulu.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "ansi-wrap": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/archy/-/archy-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://npm.prod.hulu.com/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.com/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
@@ -121,49 +121,49 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "http://npm.prod.hulu.com/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "http://npm.prod.hulu.com/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/array-differ/-/array-differ-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-each": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/array-each/-/array-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/array-each/-/array-each-1.0.1.tgz",
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-slice": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/array-slice/-/array-slice-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -172,25 +172,25 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "http://npm.prod.hulu.com/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "http://npm.prod.hulu.com/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.com/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://npm.prod.hulu.com/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.com/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
@@ -199,61 +199,61 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "async": {
       "version": "0.2.10",
-      "resolved": "http://npm.prod.hulu.com/async/-/async-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.com/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://npm.prod.hulu.com/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.com/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "http://npm.prod.hulu.com/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "http://npm.prod.hulu.com/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.com/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "http://npm.prod.hulu.com/aws4/-/aws4-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.com/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "http://npm.prod.hulu.com/base/-/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.com/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
@@ -268,7 +268,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -277,7 +277,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -286,7 +286,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -295,7 +295,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://npm.prod.hulu.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -308,7 +308,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -317,13 +317,13 @@
     },
     "beeper": {
       "version": "1.1.1",
-      "resolved": "http://npm.prod.hulu.com/beeper/-/beeper-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://npm.prod.hulu.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
@@ -333,7 +333,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "http://npm.prod.hulu.com/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.com/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
@@ -351,7 +351,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -362,13 +362,13 @@
     },
     "browser-request": {
       "version": "0.3.3",
-      "resolved": "http://npm.prod.hulu.com/browser-request/-/browser-request-0.3.3.tgz",
+      "resolved": "https://registry.npmjs.com/browser-request/-/browser-request-0.3.3.tgz",
       "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
       "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
@@ -385,13 +385,13 @@
     },
     "camelcase": {
       "version": "2.1.1",
-      "resolved": "http://npm.prod.hulu.com/camelcase/-/camelcase-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://npm.prod.hulu.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -401,7 +401,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "http://npm.prod.hulu.com/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.com/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
@@ -417,7 +417,7 @@
     },
     "chai": {
       "version": "3.4.1",
-      "resolved": "http://npm.prod.hulu.com/chai/-/chai-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.com/chai/-/chai-3.4.1.tgz",
       "integrity": "sha1-Mwri+BkSTCYYIDb6XkOojqThvYU=",
       "dev": true,
       "requires": {
@@ -428,7 +428,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://npm.prod.hulu.com/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -441,7 +441,7 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "http://npm.prod.hulu.com/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.com/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
@@ -453,7 +453,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -464,7 +464,7 @@
     },
     "cli-color": {
       "version": "0.2.3",
-      "resolved": "http://npm.prod.hulu.com/cli-color/-/cli-color-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.com/cli-color/-/cli-color-0.2.3.tgz",
       "integrity": "sha1-CiXOrlpqFgK+f3fShWPDZwAnTog=",
       "dev": true,
       "requires": {
@@ -485,25 +485,25 @@
     },
     "clone": {
       "version": "1.0.4",
-      "resolved": "http://npm.prod.hulu.com/clone/-/clone-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-buffer": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/clone-buffer/-/clone-buffer-1.0.0.tgz",
       "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
       "dev": true
     },
     "clone-stats": {
       "version": "0.0.1",
-      "resolved": "http://npm.prod.hulu.com/clone-stats/-/clone-stats-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "cloneable-readable": {
       "version": "1.1.2",
-      "resolved": "http://npm.prod.hulu.com/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
@@ -514,13 +514,13 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -535,7 +535,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://npm.prod.hulu.com/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.com/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -546,7 +546,7 @@
     },
     "coffee-coverage": {
       "version": "0.7.0",
-      "resolved": "http://npm.prod.hulu.com/coffee-coverage/-/coffee-coverage-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.com/coffee-coverage/-/coffee-coverage-0.7.0.tgz",
       "integrity": "sha1-VJMIs9sJuz8IeOvPRpW6GCsaOLI=",
       "dev": true,
       "requires": {
@@ -558,13 +558,13 @@
     },
     "coffee-script": {
       "version": "1.10.0",
-      "resolved": "http://npm.prod.hulu.com/coffee-script/-/coffee-script-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.com/coffee-script/-/coffee-script-1.10.0.tgz",
       "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -574,13 +574,13 @@
     },
     "color-support": {
       "version": "1.1.3",
-      "resolved": "http://npm.prod.hulu.com/color-support/-/color-support-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.7",
-      "resolved": "http://npm.prod.hulu.com/combined-stream/-/combined-stream-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.com/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
@@ -589,25 +589,25 @@
     },
     "commander": {
       "version": "2.19.0",
-      "resolved": "http://npm.prod.hulu.com/commander/-/commander-2.19.0.tgz",
+      "resolved": "https://registry.npmjs.com/commander/-/commander-2.19.0.tgz",
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "http://npm.prod.hulu.com/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://npm.prod.hulu.com/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-with-sourcemaps": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
       "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
       "dev": true,
       "requires": {
@@ -616,7 +616,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://npm.prod.hulu.com/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.com/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -624,25 +624,25 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cssom": {
       "version": "0.3.6",
-      "resolved": "http://npm.prod.hulu.com/cssom/-/cssom-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.com/cssom/-/cssom-0.3.6.tgz",
       "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
       "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
-      "resolved": "http://npm.prod.hulu.com/cssstyle/-/cssstyle-0.2.37.tgz",
+      "resolved": "https://registry.npmjs.com/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
@@ -651,7 +651,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "http://npm.prod.hulu.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -660,7 +660,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://npm.prod.hulu.com/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.com/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -669,7 +669,7 @@
     },
     "dateformat": {
       "version": "2.2.0",
-      "resolved": "http://npm.prod.hulu.com/dateformat/-/dateformat-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/dateformat/-/dateformat-2.2.0.tgz",
       "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true
     },
@@ -681,7 +681,7 @@
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "http://npm.prod.hulu.com/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.com/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
@@ -690,19 +690,19 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "http://npm.prod.hulu.com/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "http://npm.prod.hulu.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "http://npm.prod.hulu.com/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
@@ -711,7 +711,7 @@
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "resolved": "http://npm.prod.hulu.com/type-detect/-/type-detect-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.com/type-detect/-/type-detect-0.1.1.tgz",
           "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
@@ -719,13 +719,13 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://npm.prod.hulu.com/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "defaults": {
       "version": "1.0.3",
-      "resolved": "http://npm.prod.hulu.com/defaults/-/defaults-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
@@ -734,7 +734,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
@@ -744,7 +744,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -753,7 +753,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -762,7 +762,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://npm.prod.hulu.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -775,7 +775,7 @@
     },
     "del": {
       "version": "2.2.2",
-      "resolved": "http://npm.prod.hulu.com/del/-/del-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.com/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
@@ -790,31 +790,31 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "deprecated": {
       "version": "0.0.1",
-      "resolved": "http://npm.prod.hulu.com/deprecated/-/deprecated-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/deprecated/-/deprecated-0.0.1.tgz",
       "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
       "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "diff": {
       "version": "1.4.0",
-      "resolved": "http://npm.prod.hulu.com/diff/-/diff-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.com/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
     "dom-serializer": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
@@ -824,13 +824,13 @@
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "http://npm.prod.hulu.com/domelementtype/-/domelementtype-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.com/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
       "version": "2.4.2",
-      "resolved": "http://npm.prod.hulu.com/domhandler/-/domhandler-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.com/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
@@ -839,7 +839,7 @@
     },
     "domutils": {
       "version": "1.7.0",
-      "resolved": "http://npm.prod.hulu.com/domutils/-/domutils-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.com/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
@@ -849,7 +849,7 @@
     },
     "dot-object": {
       "version": "1.7.1",
-      "resolved": "http://npm.prod.hulu.com/dot-object/-/dot-object-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.com/dot-object/-/dot-object-1.7.1.tgz",
       "integrity": "sha512-XJWGenQT/O9TOOip9JzY6Gtk73Cp8qnGnObeSvwdHA9h3YHXgma6qobPRHc8fxHugRpXiHWJ9XiWasXn+Dk2Kg==",
       "dev": true,
       "requires": {
@@ -859,13 +859,13 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "duplexer2": {
       "version": "0.0.2",
-      "resolved": "http://npm.prod.hulu.com/duplexer2/-/duplexer2-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
@@ -874,7 +874,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -884,7 +884,7 @@
     },
     "end-of-stream": {
       "version": "0.1.5",
-      "resolved": "http://npm.prod.hulu.com/end-of-stream/-/end-of-stream-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.com/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
       "requires": {
@@ -893,7 +893,7 @@
       "dependencies": {
         "once": {
           "version": "1.3.3",
-          "resolved": "http://npm.prod.hulu.com/once/-/once-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.com/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
@@ -904,13 +904,13 @@
     },
     "entities": {
       "version": "1.1.2",
-      "resolved": "http://npm.prod.hulu.com/entities/-/entities-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "http://npm.prod.hulu.com/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.com/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
@@ -919,19 +919,19 @@
     },
     "es5-ext": {
       "version": "0.9.2",
-      "resolved": "http://npm.prod.hulu.com/es5-ext/-/es5-ext-0.9.2.tgz",
+      "resolved": "https://registry.npmjs.com/es5-ext/-/es5-ext-0.9.2.tgz",
       "integrity": "sha1-0uMJ0fIjsHGGSINaz1uII6gGH4o=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://npm.prod.hulu.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escodegen": {
       "version": "1.11.1",
-      "resolved": "http://npm.prod.hulu.com/escodegen/-/escodegen-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.com/escodegen/-/escodegen-1.11.1.tgz",
       "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
       "dev": true,
       "requires": {
@@ -944,7 +944,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://npm.prod.hulu.com/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.com/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
@@ -953,25 +953,25 @@
     },
     "esprima": {
       "version": "3.1.3",
-      "resolved": "http://npm.prod.hulu.com/esprima/-/esprima-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
       "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "http://npm.prod.hulu.com/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "http://npm.prod.hulu.com/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.2.2",
-      "resolved": "http://npm.prod.hulu.com/event-emitter/-/event-emitter-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.com/event-emitter/-/event-emitter-0.2.2.tgz",
       "integrity": "sha1-yB43JOtVQHxaDV7jKZQR9wD1QpE=",
       "dev": true,
       "requires": {
@@ -980,7 +980,7 @@
     },
     "event-stream": {
       "version": "3.0.20",
-      "resolved": "http://npm.prod.hulu.com/event-stream/-/event-stream-3.0.20.tgz",
+      "resolved": "https://registry.npmjs.com/event-stream/-/event-stream-3.0.20.tgz",
       "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
       "dev": true,
       "requires": {
@@ -995,7 +995,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "http://npm.prod.hulu.com/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.com/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -1010,7 +1010,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -1019,7 +1019,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1030,7 +1030,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "http://npm.prod.hulu.com/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -1039,13 +1039,13 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "http://npm.prod.hulu.com/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -1055,7 +1055,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://npm.prod.hulu.com/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
@@ -1066,7 +1066,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "http://npm.prod.hulu.com/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
@@ -1082,7 +1082,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -1091,7 +1091,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1100,7 +1100,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -1109,7 +1109,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -1118,7 +1118,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://npm.prod.hulu.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -1131,13 +1131,13 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://npm.prod.hulu.com/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.com/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fancy-log": {
       "version": "1.3.3",
-      "resolved": "http://npm.prod.hulu.com/fancy-log/-/fancy-log-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.com/fancy-log/-/fancy-log-1.3.3.tgz",
       "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
       "dev": true,
       "requires": {
@@ -1149,25 +1149,25 @@
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "http://npm.prod.hulu.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://npm.prod.hulu.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "http://npm.prod.hulu.com/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -1179,7 +1179,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1190,13 +1190,13 @@
     },
     "find-index": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/find-index/-/find-index-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/find-index/-/find-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
     },
     "find-up": {
       "version": "1.1.2",
-      "resolved": "http://npm.prod.hulu.com/find-up/-/find-up-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
@@ -1206,7 +1206,7 @@
     },
     "findup-sync": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/findup-sync/-/findup-sync-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
@@ -1218,7 +1218,7 @@
     },
     "fined": {
       "version": "1.1.1",
-      "resolved": "http://npm.prod.hulu.com/fined/-/fined-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/fined/-/fined-1.1.1.tgz",
       "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
       "dev": true,
       "requires": {
@@ -1231,25 +1231,25 @@
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
     },
     "flagged-respawn": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
       "dev": true
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/for-own/-/for-own-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
@@ -1258,13 +1258,13 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "http://npm.prod.hulu.com/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.com/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "http://npm.prod.hulu.com/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.com/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
@@ -1275,7 +1275,7 @@
     },
     "formatio": {
       "version": "1.1.1",
-      "resolved": "http://npm.prod.hulu.com/formatio/-/formatio-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
@@ -1284,7 +1284,7 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "http://npm.prod.hulu.com/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -1293,19 +1293,19 @@
     },
     "from": {
       "version": "0.1.7",
-      "resolved": "http://npm.prod.hulu.com/from/-/from-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.com/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "gaze": {
       "version": "0.5.2",
-      "resolved": "http://npm.prod.hulu.com/gaze/-/gaze-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.com/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
@@ -1314,19 +1314,19 @@
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "http://npm.prod.hulu.com/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "http://npm.prod.hulu.com/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.com/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://npm.prod.hulu.com/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.com/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -1335,7 +1335,7 @@
     },
     "glob": {
       "version": "7.1.3",
-      "resolved": "http://npm.prod.hulu.com/glob/-/glob-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
@@ -1349,7 +1349,7 @@
     },
     "glob-stream": {
       "version": "3.1.18",
-      "resolved": "http://npm.prod.hulu.com/glob-stream/-/glob-stream-3.1.18.tgz",
+      "resolved": "https://registry.npmjs.com/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "requires": {
@@ -1363,7 +1363,7 @@
       "dependencies": {
         "glob": {
           "version": "4.5.3",
-          "resolved": "http://npm.prod.hulu.com/glob/-/glob-4.5.3.tgz",
+          "resolved": "https://registry.npmjs.com/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
@@ -1375,7 +1375,7 @@
         },
         "minimatch": {
           "version": "2.0.10",
-          "resolved": "http://npm.prod.hulu.com/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.com/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
@@ -1384,7 +1384,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -1396,7 +1396,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://npm.prod.hulu.com/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.com/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -1408,7 +1408,7 @@
     },
     "glob-watcher": {
       "version": "0.0.6",
-      "resolved": "http://npm.prod.hulu.com/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.com/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
@@ -1417,7 +1417,7 @@
     },
     "glob2base": {
       "version": "0.0.12",
-      "resolved": "http://npm.prod.hulu.com/glob2base/-/glob2base-0.0.12.tgz",
+      "resolved": "https://registry.npmjs.com/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
@@ -1426,7 +1426,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/global-modules/-/global-modules-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
@@ -1437,7 +1437,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
@@ -1450,7 +1450,7 @@
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "http://npm.prod.hulu.com/globby/-/globby-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
@@ -1464,7 +1464,7 @@
     },
     "globule": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/globule/-/globule-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
@@ -1475,7 +1475,7 @@
       "dependencies": {
         "glob": {
           "version": "3.1.21",
-          "resolved": "http://npm.prod.hulu.com/glob/-/glob-3.1.21.tgz",
+          "resolved": "https://registry.npmjs.com/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
@@ -1486,25 +1486,25 @@
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "resolved": "http://npm.prod.hulu.com/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.com/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "resolved": "http://npm.prod.hulu.com/inherits/-/inherits-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.com/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "lodash": {
           "version": "1.0.2",
-          "resolved": "http://npm.prod.hulu.com/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.com/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "http://npm.prod.hulu.com/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.com/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -1516,7 +1516,7 @@
     },
     "glogg": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/glogg/-/glogg-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/glogg/-/glogg-1.0.2.tgz",
       "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
       "dev": true,
       "requires": {
@@ -1525,7 +1525,7 @@
     },
     "graceful-fs": {
       "version": "3.0.11",
-      "resolved": "http://npm.prod.hulu.com/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "resolved": "https://registry.npmjs.com/graceful-fs/-/graceful-fs-3.0.11.tgz",
       "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
       "dev": true,
       "requires": {
@@ -1540,7 +1540,7 @@
     },
     "gulp": {
       "version": "3.9.1",
-      "resolved": "http://npm.prod.hulu.com/gulp/-/gulp-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.com/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
@@ -1561,7 +1561,7 @@
     },
     "gulp-bump": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/gulp-bump/-/gulp-bump-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-bump/-/gulp-bump-1.0.0.tgz",
       "integrity": "sha1-XofEsSlyalzphvIjDnU3vzzecqw=",
       "dev": true,
       "requires": {
@@ -1574,7 +1574,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -1586,13 +1586,13 @@
         },
         "semver": {
           "version": "5.6.0",
-          "resolved": "http://npm.prod.hulu.com/semver/-/semver-5.6.0.tgz",
+          "resolved": "https://registry.npmjs.com/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true
         },
         "through2": {
           "version": "0.5.1",
-          "resolved": "http://npm.prod.hulu.com/through2/-/through2-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.com/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
@@ -1602,7 +1602,7 @@
         },
         "xtend": {
           "version": "3.0.0",
-          "resolved": "http://npm.prod.hulu.com/xtend/-/xtend-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/xtend/-/xtend-3.0.0.tgz",
           "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
           "dev": true
         }
@@ -1610,7 +1610,7 @@
     },
     "gulp-coffee": {
       "version": "2.3.5",
-      "resolved": "http://npm.prod.hulu.com/gulp-coffee/-/gulp-coffee-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-coffee/-/gulp-coffee-2.3.5.tgz",
       "integrity": "sha512-PbgPGZVyYFnBTYtfYkVN6jcK8Qsuh3BxycPzvu8y5lZroCw3/x1m25KeyEDX110KsVLDmJxoULjscR21VEN4wA==",
       "dev": true,
       "requires": {
@@ -1623,7 +1623,7 @@
       "dependencies": {
         "coffeescript": {
           "version": "1.12.7",
-          "resolved": "http://npm.prod.hulu.com/coffeescript/-/coffeescript-1.12.7.tgz",
+          "resolved": "https://registry.npmjs.com/coffeescript/-/coffeescript-1.12.7.tgz",
           "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
           "dev": true
         }
@@ -1641,7 +1641,7 @@
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "resolved": "http://npm.prod.hulu.com/argparse/-/argparse-0.1.16.tgz",
+          "resolved": "https://registry.npmjs.com/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
@@ -1651,7 +1651,7 @@
         },
         "coffee-coverage": {
           "version": "0.4.6",
-          "resolved": "http://npm.prod.hulu.com/coffee-coverage/-/coffee-coverage-0.4.6.tgz",
+          "resolved": "https://registry.npmjs.com/coffee-coverage/-/coffee-coverage-0.4.6.tgz",
           "integrity": "sha1-hNxhxPDyhlEBoc4vO4NZSkK2GTA=",
           "dev": true,
           "requires": {
@@ -1662,7 +1662,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -1674,7 +1674,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://npm.prod.hulu.com/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.com/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -1686,7 +1686,7 @@
     },
     "gulp-concat": {
       "version": "2.6.1",
-      "resolved": "http://npm.prod.hulu.com/gulp-concat/-/gulp-concat-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "dev": true,
       "requires": {
@@ -1697,25 +1697,25 @@
       "dependencies": {
         "clone": {
           "version": "2.1.2",
-          "resolved": "http://npm.prod.hulu.com/clone/-/clone-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.com/clone/-/clone-2.1.2.tgz",
           "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
           "dev": true
         },
         "clone-stats": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/clone-stats/-/clone-stats-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/clone-stats/-/clone-stats-1.0.0.tgz",
           "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
           "dev": true
         },
         "replace-ext": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/replace-ext/-/replace-ext-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/replace-ext/-/replace-ext-1.0.0.tgz",
           "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
           "dev": true
         },
         "vinyl": {
           "version": "2.2.0",
-          "resolved": "http://npm.prod.hulu.com/vinyl/-/vinyl-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.com/vinyl/-/vinyl-2.2.0.tgz",
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
@@ -1731,7 +1731,7 @@
     },
     "gulp-header": {
       "version": "1.7.1",
-      "resolved": "http://npm.prod.hulu.com/gulp-header/-/gulp-header-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-header/-/gulp-header-1.7.1.tgz",
       "integrity": "sha1-41J5hkkQdr7JdNuYteHCT0UzxC4=",
       "dev": true,
       "requires": {
@@ -1743,7 +1743,7 @@
     },
     "gulp-mocha": {
       "version": "2.1.3",
-      "resolved": "http://npm.prod.hulu.com/gulp-mocha/-/gulp-mocha-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-mocha/-/gulp-mocha-2.1.3.tgz",
       "integrity": "sha1-6QbyUV6tGycydwA/YNWErOuU82I=",
       "dev": true,
       "requires": {
@@ -1757,7 +1757,7 @@
     },
     "gulp-prompt": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/gulp-prompt/-/gulp-prompt-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-prompt/-/gulp-prompt-0.1.2.tgz",
       "integrity": "sha1-BsmZvedk4++sYCJTbMK7Aiq4N1A=",
       "dev": true,
       "requires": {
@@ -1767,13 +1767,13 @@
     },
     "gulp-rename": {
       "version": "1.2.3",
-      "resolved": "http://npm.prod.hulu.com/gulp-rename/-/gulp-rename-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-rename/-/gulp-rename-1.2.3.tgz",
       "integrity": "sha512-CmdPM0BjJ105QCX1fk+j7NGhiN/1rCl9HLGss+KllBS/tdYadpjTxqdKyh/5fNV+M3yjT1MFz5z93bXdrTyzAw==",
       "dev": true
     },
     "gulp-shell": {
       "version": "0.5.2",
-      "resolved": "http://npm.prod.hulu.com/gulp-shell/-/gulp-shell-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-shell/-/gulp-shell-0.5.2.tgz",
       "integrity": "sha1-pJWcoGUa0ce7/nCy0K27tOGuqY0=",
       "dev": true,
       "requires": {
@@ -1785,13 +1785,13 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://npm.prod.hulu.com/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.com/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "lodash": {
           "version": "4.17.11",
-          "resolved": "http://npm.prod.hulu.com/lodash/-/lodash-4.17.11.tgz",
+          "resolved": "https://registry.npmjs.com/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         }
@@ -1832,7 +1832,7 @@
     },
     "gulp-util": {
       "version": "3.0.8",
-      "resolved": "http://npm.prod.hulu.com/gulp-util/-/gulp-util-3.0.8.tgz",
+      "resolved": "https://registry.npmjs.com/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
@@ -1858,7 +1858,7 @@
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "resolved": "http://npm.prod.hulu.com/object-assign/-/object-assign-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
           "dev": true
         }
@@ -1866,7 +1866,7 @@
     },
     "gulplog": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/gulplog/-/gulplog-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
@@ -1875,13 +1875,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "http://npm.prod.hulu.com/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
@@ -1891,7 +1891,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -1900,7 +1900,7 @@
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
@@ -1909,7 +1909,7 @@
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -1920,7 +1920,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -1930,7 +1930,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -1941,7 +1941,7 @@
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "http://npm.prod.hulu.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
@@ -1950,13 +1950,13 @@
     },
     "hosted-git-info": {
       "version": "2.7.1",
-      "resolved": "http://npm.prod.hulu.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "htmlparser2": {
       "version": "3.10.1",
-      "resolved": "http://npm.prod.hulu.com/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "resolved": "https://registry.npmjs.com/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
@@ -1970,7 +1970,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.1.1",
-          "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-3.1.1.tgz",
           "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "dev": true,
           "requires": {
@@ -1981,7 +1981,7 @@
         },
         "string_decoder": {
           "version": "1.2.0",
-          "resolved": "http://npm.prod.hulu.com/string_decoder/-/string_decoder-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.com/string_decoder/-/string_decoder-1.2.0.tgz",
           "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "dev": true,
           "requires": {
@@ -1992,7 +1992,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://npm.prod.hulu.com/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -2003,7 +2003,7 @@
     },
     "indent-string": {
       "version": "2.1.0",
-      "resolved": "http://npm.prod.hulu.com/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
@@ -2012,7 +2012,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://npm.prod.hulu.com/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.com/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -2022,19 +2022,19 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "http://npm.prod.hulu.com/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "http://npm.prod.hulu.com/ini/-/ini-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.com/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
       "version": "0.3.5",
-      "resolved": "http://npm.prod.hulu.com/inquirer/-/inquirer-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.com/inquirer/-/inquirer-0.3.5.tgz",
       "integrity": "sha1-p4vgZKyavxaBR8Ahaakx2aSDqfY=",
       "dev": true,
       "requires": {
@@ -2046,7 +2046,7 @@
       "dependencies": {
         "lodash": {
           "version": "1.2.1",
-          "resolved": "http://npm.prod.hulu.com/lodash/-/lodash-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.com/lodash/-/lodash-1.2.1.tgz",
           "integrity": "sha1-7UexbkbwaytAMJto6RY8F+k+owQ=",
           "dev": true
         }
@@ -2054,13 +2054,13 @@
     },
     "interpret": {
       "version": "1.2.0",
-      "resolved": "http://npm.prod.hulu.com/interpret/-/interpret-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
     "is-absolute": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/is-absolute/-/is-absolute-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
@@ -2070,7 +2070,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://npm.prod.hulu.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -2079,7 +2079,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -2090,19 +2090,19 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "http://npm.prod.hulu.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "http://npm.prod.hulu.com/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.com/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://npm.prod.hulu.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -2111,7 +2111,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -2122,7 +2122,7 @@
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://npm.prod.hulu.com/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.com/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
@@ -2133,7 +2133,7 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
@@ -2141,19 +2141,19 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "http://npm.prod.hulu.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -2162,7 +2162,7 @@
     },
     "is-glob": {
       "version": "3.1.0",
-      "resolved": "http://npm.prod.hulu.com/is-glob/-/is-glob-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
@@ -2171,7 +2171,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "http://npm.prod.hulu.com/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -2180,7 +2180,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -2191,13 +2191,13 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
@@ -2206,7 +2206,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
@@ -2215,7 +2215,7 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "http://npm.prod.hulu.com/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
@@ -2224,7 +2224,7 @@
     },
     "is-relative": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/is-relative/-/is-relative-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/is-relative/-/is-relative-1.0.0.tgz",
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
@@ -2233,13 +2233,13 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-unc-path": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
@@ -2248,43 +2248,43 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "http://npm.prod.hulu.com/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "isarray": {
       "version": "0.0.1",
-      "resolved": "http://npm.prod.hulu.com/isarray/-/isarray-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "http://npm.prod.hulu.com/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "jade": {
       "version": "0.26.3",
-      "resolved": "http://npm.prod.hulu.com/jade/-/jade-0.26.3.tgz",
+      "resolved": "https://registry.npmjs.com/jade/-/jade-0.26.3.tgz",
       "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
       "dev": true,
       "requires": {
@@ -2294,13 +2294,13 @@
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "resolved": "http://npm.prod.hulu.com/commander/-/commander-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.com/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.3.0",
-          "resolved": "http://npm.prod.hulu.com/mkdirp/-/mkdirp-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.com/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
@@ -2308,13 +2308,13 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsdom": {
       "version": "7.0.2",
-      "resolved": "http://npm.prod.hulu.com/jsdom/-/jsdom-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/jsdom/-/jsdom-7.0.2.tgz",
       "integrity": "sha1-OACVWFVtzqT9os/a27K1Z8edBWI=",
       "dev": true,
       "requires": {
@@ -2338,25 +2338,25 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://npm.prod.hulu.com/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.com/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://npm.prod.hulu.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://npm.prod.hulu.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://npm.prod.hulu.com/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.com/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -2368,7 +2368,7 @@
     },
     "kind-of": {
       "version": "6.0.2",
-      "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
@@ -2380,7 +2380,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "http://npm.prod.hulu.com/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.com/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -2390,7 +2390,7 @@
     },
     "liftoff": {
       "version": "2.5.0",
-      "resolved": "http://npm.prod.hulu.com/liftoff/-/liftoff-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.com/liftoff/-/liftoff-2.5.0.tgz",
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
@@ -2406,7 +2406,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -2419,13 +2419,13 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.15",
-          "resolved": "http://npm.prod.hulu.com/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "resolved": "https://registry.npmjs.com/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "http://npm.prod.hulu.com/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -2436,67 +2436,67 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "resolved": "http://npm.prod.hulu.com/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "https://registry.npmjs.com/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://npm.prod.hulu.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basetostring": {
       "version": "3.0.1",
-      "resolved": "http://npm.prod.hulu.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
       "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
       "dev": true
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "resolved": "http://npm.prod.hulu.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://npm.prod.hulu.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://npm.prod.hulu.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "resolved": "http://npm.prod.hulu.com/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
       "dev": true
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "resolved": "http://npm.prod.hulu.com/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "http://npm.prod.hulu.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash._root": {
       "version": "3.0.1",
-      "resolved": "http://npm.prod.hulu.com/lodash._root/-/lodash._root-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/lodash._root/-/lodash._root-3.0.1.tgz",
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
     "lodash.escape": {
       "version": "3.2.0",
-      "resolved": "http://npm.prod.hulu.com/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
@@ -2505,19 +2505,19 @@
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://npm.prod.hulu.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://npm.prod.hulu.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://npm.prod.hulu.com/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -2528,13 +2528,13 @@
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "http://npm.prod.hulu.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.template": {
       "version": "3.6.2",
-      "resolved": "http://npm.prod.hulu.com/lodash.template/-/lodash.template-3.6.2.tgz",
+      "resolved": "https://registry.npmjs.com/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
@@ -2551,7 +2551,7 @@
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
-      "resolved": "http://npm.prod.hulu.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
@@ -2561,7 +2561,7 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "http://npm.prod.hulu.com/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.com/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
@@ -2573,7 +2573,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "http://npm.prod.hulu.com/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.com/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -2583,13 +2583,13 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "http://npm.prod.hulu.com/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.com/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "make-iterator": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/make-iterator/-/make-iterator-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/make-iterator/-/make-iterator-1.0.1.tgz",
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
@@ -2598,25 +2598,25 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "http://npm.prod.hulu.com/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.com/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-stream": {
       "version": "0.0.7",
-      "resolved": "http://npm.prod.hulu.com/map-stream/-/map-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.com/map-stream/-/map-stream-0.0.7.tgz",
       "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -2625,7 +2625,7 @@
     },
     "memoizee": {
       "version": "0.2.6",
-      "resolved": "http://npm.prod.hulu.com/memoizee/-/memoizee-0.2.6.tgz",
+      "resolved": "https://registry.npmjs.com/memoizee/-/memoizee-0.2.6.tgz",
       "integrity": "sha1-u0WnrQJTAILxYSZx2rNSGc0uB0E=",
       "dev": true,
       "requires": {
@@ -2636,7 +2636,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://npm.prod.hulu.com/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.com/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -2654,13 +2654,13 @@
     },
     "merge": {
       "version": "1.2.1",
-      "resolved": "http://npm.prod.hulu.com/merge/-/merge-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/merge/-/merge-1.2.1.tgz",
       "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "http://npm.prod.hulu.com/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.com/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
@@ -2681,13 +2681,13 @@
     },
     "mime-db": {
       "version": "1.38.0",
-      "resolved": "http://npm.prod.hulu.com/mime-db/-/mime-db-1.38.0.tgz",
+      "resolved": "https://registry.npmjs.com/mime-db/-/mime-db-1.38.0.tgz",
       "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.22",
-      "resolved": "http://npm.prod.hulu.com/mime-types/-/mime-types-2.1.22.tgz",
+      "resolved": "https://registry.npmjs.com/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "dev": true,
       "requires": {
@@ -2696,7 +2696,7 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "http://npm.prod.hulu.com/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
@@ -2705,13 +2705,13 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://npm.prod.hulu.com/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
-      "resolved": "http://npm.prod.hulu.com/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.com/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
@@ -2721,7 +2721,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://npm.prod.hulu.com/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
@@ -2732,7 +2732,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://npm.prod.hulu.com/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.com/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2741,7 +2741,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://npm.prod.hulu.com/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.com/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -2749,7 +2749,7 @@
     },
     "mocha": {
       "version": "2.3.4",
-      "resolved": "http://npm.prod.hulu.com/mocha/-/mocha-2.3.4.tgz",
+      "resolved": "https://registry.npmjs.com/mocha/-/mocha-2.3.4.tgz",
       "integrity": "sha1-himm+wRPLSJapLgaKuLQAWmesmY=",
       "dev": true,
       "requires": {
@@ -2766,13 +2766,13 @@
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "resolved": "http://npm.prod.hulu.com/commander/-/commander-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.com/commander/-/commander-2.3.0.tgz",
           "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
-          "resolved": "http://npm.prod.hulu.com/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.com/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -2781,13 +2781,13 @@
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "resolved": "http://npm.prod.hulu.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
           "dev": true
         },
         "glob": {
           "version": "3.2.3",
-          "resolved": "http://npm.prod.hulu.com/glob/-/glob-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.com/glob/-/glob-3.2.3.tgz",
           "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
           "dev": true,
           "requires": {
@@ -2798,7 +2798,7 @@
         },
         "graceful-fs": {
           "version": "2.0.3",
-          "resolved": "http://npm.prod.hulu.com/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.com/graceful-fs/-/graceful-fs-2.0.3.tgz",
           "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
           "dev": true
         },
@@ -2810,7 +2810,7 @@
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "http://npm.prod.hulu.com/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.com/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -2820,13 +2820,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://npm.prod.hulu.com/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.com/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "http://npm.prod.hulu.com/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.com/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -2835,13 +2835,13 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "http://npm.prod.hulu.com/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.com/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "supports-color": {
           "version": "1.2.0",
-          "resolved": "http://npm.prod.hulu.com/supports-color/-/supports-color-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.com/supports-color/-/supports-color-1.2.0.tgz",
           "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
           "dev": true
         }
@@ -2849,13 +2849,13 @@
     },
     "mocha-lcov-reporter": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/mocha-lcov-reporter/-/mocha-lcov-reporter-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/mocha-lcov-reporter/-/mocha-lcov-reporter-1.0.0.tgz",
       "integrity": "sha1-zw3aKwYJnYgEi2wR1WIoJjC0nL8=",
       "dev": true
     },
     "mocha-multi": {
       "version": "0.7.2",
-      "resolved": "http://npm.prod.hulu.com/mocha-multi/-/mocha-multi-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.com/mocha-multi/-/mocha-multi-0.7.2.tgz",
       "integrity": "sha1-+w1cuhKCFFF5RYmgrEXGvihp8ns=",
       "dev": true,
       "requires": {
@@ -2864,7 +2864,7 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "resolved": "http://npm.prod.hulu.com/debug/-/debug-0.7.4.tgz",
+          "resolved": "https://registry.npmjs.com/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         }
@@ -2872,13 +2872,13 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multipipe": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/multipipe/-/multipipe-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
       "dev": true,
       "requires": {
@@ -2887,13 +2887,13 @@
     },
     "mute-stream": {
       "version": "0.0.3",
-      "resolved": "http://npm.prod.hulu.com/mute-stream/-/mute-stream-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/mute-stream/-/mute-stream-0.0.3.tgz",
       "integrity": "sha1-8JwJDTM7MGP2Fcu8ynGzSYk/AVI=",
       "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "http://npm.prod.hulu.com/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.com/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
@@ -2912,19 +2912,19 @@
     },
     "natives": {
       "version": "1.1.6",
-      "resolved": "http://npm.prod.hulu.com/natives/-/natives-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.com/natives/-/natives-1.1.6.tgz",
       "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "next-tick": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/next-tick/-/next-tick-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/next-tick/-/next-tick-0.1.0.tgz",
       "integrity": "sha1-GRLM6OubaX1kD7upT48A3sO5Qlk=",
       "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "http://npm.prod.hulu.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
@@ -2936,7 +2936,7 @@
     },
     "npm": {
       "version": "3.10.10",
-      "resolved": "http://npm.prod.hulu.com/npm/-/npm-3.10.10.tgz",
+      "resolved": "https://registry.npmjs.com/npm/-/npm-3.10.10.tgz",
       "integrity": "sha1-Wx1XfkyIadbIYDvInpzRY3MD5G4=",
       "dev": true,
       "requires": {
@@ -5083,31 +5083,31 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nwmatcher": {
       "version": "1.4.4",
-      "resolved": "http://npm.prod.hulu.com/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "resolved": "https://registry.npmjs.com/nwmatcher/-/nwmatcher-1.4.4.tgz",
       "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "http://npm.prod.hulu.com/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.com/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "http://npm.prod.hulu.com/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -5118,7 +5118,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5127,7 +5127,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5138,7 +5138,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -5147,7 +5147,7 @@
     },
     "object.defaults": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/object.defaults/-/object.defaults-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
@@ -5159,7 +5159,7 @@
     },
     "object.map": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/object.map/-/object.map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
@@ -5169,7 +5169,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://npm.prod.hulu.com/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.com/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -5178,7 +5178,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://npm.prod.hulu.com/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.com/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -5187,7 +5187,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "http://npm.prod.hulu.com/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.com/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -5201,7 +5201,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/wordwrap/-/wordwrap-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
@@ -5209,7 +5209,7 @@
     },
     "orchestrator": {
       "version": "0.3.8",
-      "resolved": "http://npm.prod.hulu.com/orchestrator/-/orchestrator-0.3.8.tgz",
+      "resolved": "https://registry.npmjs.com/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
@@ -5220,25 +5220,25 @@
     },
     "ordered-read-streams": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
       "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "parse-filepath": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
@@ -5249,7 +5249,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "http://npm.prod.hulu.com/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -5258,31 +5258,31 @@
     },
     "parse-node-version": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/parse-node-version/-/parse-node-version-1.0.1.tgz",
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
       "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "parse5": {
       "version": "1.5.1",
-      "resolved": "http://npm.prod.hulu.com/parse5/-/parse5-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.com/parse5/-/parse5-1.5.1.tgz",
       "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
-      "resolved": "http://npm.prod.hulu.com/path-exists/-/path-exists-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
@@ -5291,25 +5291,25 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "http://npm.prod.hulu.com/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.com/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-root": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/path-root/-/path-root-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
@@ -5318,13 +5318,13 @@
     },
     "path-root-regex": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
     "path-type": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/path-type/-/path-type-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
@@ -5335,7 +5335,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.15",
-          "resolved": "http://npm.prod.hulu.com/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "resolved": "https://registry.npmjs.com/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
         }
@@ -5343,7 +5343,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://npm.prod.hulu.com/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.com/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -5352,25 +5352,25 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "http://npm.prod.hulu.com/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://npm.prod.hulu.com/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.com/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "http://npm.prod.hulu.com/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "http://npm.prod.hulu.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -5379,13 +5379,13 @@
     },
     "pkginfo": {
       "version": "0.4.1",
-      "resolved": "http://npm.prod.hulu.com/pkginfo/-/pkginfo-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.com/pkginfo/-/pkginfo-0.4.1.tgz",
       "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
       "dev": true
     },
     "plugin-error": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/plugin-error/-/plugin-error-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/plugin-error/-/plugin-error-0.1.2.tgz",
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "dev": true,
       "requires": {
@@ -5398,7 +5398,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "1.1.0",
-          "resolved": "http://npm.prod.hulu.com/arr-diff/-/arr-diff-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.com/arr-diff/-/arr-diff-1.1.0.tgz",
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
@@ -5408,19 +5408,19 @@
         },
         "arr-union": {
           "version": "2.1.0",
-          "resolved": "http://npm.prod.hulu.com/arr-union/-/arr-union-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.com/arr-union/-/arr-union-2.1.0.tgz",
           "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
           "dev": true
         },
         "array-slice": {
           "version": "0.2.3",
-          "resolved": "http://npm.prod.hulu.com/array-slice/-/array-slice-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.com/array-slice/-/array-slice-0.2.3.tgz",
           "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
           "dev": true
         },
         "extend-shallow": {
           "version": "1.1.4",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-1.1.4.tgz",
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
@@ -5429,7 +5429,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         }
@@ -5437,7 +5437,7 @@
     },
     "plugin-log": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/plugin-log/-/plugin-log-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/plugin-log/-/plugin-log-0.1.0.tgz",
       "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
       "dev": true,
       "requires": {
@@ -5447,7 +5447,7 @@
       "dependencies": {
         "dateformat": {
           "version": "1.0.12",
-          "resolved": "http://npm.prod.hulu.com/dateformat/-/dateformat-1.0.12.tgz",
+          "resolved": "https://registry.npmjs.com/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
@@ -5459,55 +5459,55 @@
     },
     "plur": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/plur/-/plur-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/plur/-/plur-1.0.0.tgz",
       "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
       "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://npm.prod.hulu.com/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://npm.prod.hulu.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "psl": {
       "version": "1.1.31",
-      "resolved": "http://npm.prod.hulu.com/psl/-/psl-1.1.31.tgz",
+      "resolved": "https://registry.npmjs.com/psl/-/psl-1.1.31.tgz",
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://npm.prod.hulu.com/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "http://npm.prod.hulu.com/qs/-/qs-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.com/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/read-pkg/-/read-pkg-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
@@ -5518,7 +5518,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
@@ -5528,7 +5528,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
@@ -5540,7 +5540,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "http://npm.prod.hulu.com/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.com/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -5549,7 +5549,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
@@ -5559,7 +5559,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
@@ -5569,25 +5569,25 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "http://npm.prod.hulu.com/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.com/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "http://npm.prod.hulu.com/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.com/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "http://npm.prod.hulu.com/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -5596,13 +5596,13 @@
     },
     "replace-ext": {
       "version": "0.0.1",
-      "resolved": "http://npm.prod.hulu.com/replace-ext/-/replace-ext-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "http://npm.prod.hulu.com/request/-/request-2.88.0.tgz",
+      "resolved": "https://registry.npmjs.com/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
@@ -5630,13 +5630,13 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "http://npm.prod.hulu.com/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.com/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "http://npm.prod.hulu.com/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "resolved": "https://registry.npmjs.com/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
@@ -5648,7 +5648,7 @@
     },
     "resolve": {
       "version": "1.10.0",
-      "resolved": "http://npm.prod.hulu.com/resolve/-/resolve-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.com/resolve/-/resolve-1.10.0.tgz",
       "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
@@ -5657,7 +5657,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
@@ -5667,19 +5667,19 @@
     },
     "resolve-from": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/resolve-from/-/resolve-from-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "http://npm.prod.hulu.com/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "http://npm.prod.hulu.com/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.com/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
@@ -5694,7 +5694,7 @@
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "http://npm.prod.hulu.com/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.com/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
@@ -5703,13 +5703,13 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://npm.prod.hulu.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -5718,31 +5718,31 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "http://npm.prod.hulu.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "http://npm.prod.hulu.com/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "semver": {
       "version": "4.3.6",
-      "resolved": "http://npm.prod.hulu.com/semver/-/semver-4.3.6.tgz",
+      "resolved": "https://registry.npmjs.com/semver/-/semver-4.3.6.tgz",
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
       "dev": true
     },
     "sequencify": {
       "version": "0.0.7",
-      "resolved": "http://npm.prod.hulu.com/sequencify/-/sequencify-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.com/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/set-value/-/set-value-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
@@ -5754,7 +5754,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -5765,19 +5765,19 @@
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "http://npm.prod.hulu.com/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "sinon": {
       "version": "1.17.7",
-      "resolved": "http://npm.prod.hulu.com/sinon/-/sinon-1.17.7.tgz",
+      "resolved": "https://registry.npmjs.com/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
@@ -5789,7 +5789,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "http://npm.prod.hulu.com/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.com/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
@@ -5805,7 +5805,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5814,7 +5814,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -5825,7 +5825,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "http://npm.prod.hulu.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
@@ -5836,7 +5836,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -5845,7 +5845,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -5854,7 +5854,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -5863,7 +5863,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://npm.prod.hulu.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -5876,7 +5876,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "http://npm.prod.hulu.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
@@ -5885,7 +5885,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5896,13 +5896,13 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "http://npm.prod.hulu.com/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.com/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "http://npm.prod.hulu.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
@@ -5915,19 +5915,19 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "http://npm.prod.hulu.com/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.com/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "sparkles": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/sparkles/-/sparkles-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/sparkles/-/sparkles-1.0.1.tgz",
       "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "http://npm.prod.hulu.com/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
@@ -5937,13 +5937,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "http://npm.prod.hulu.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "http://npm.prod.hulu.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
@@ -5953,13 +5953,13 @@
     },
     "spdx-license-ids": {
       "version": "3.0.3",
-      "resolved": "http://npm.prod.hulu.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
       "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
     },
     "split": {
       "version": "0.2.10",
-      "resolved": "http://npm.prod.hulu.com/split/-/split-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.com/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "dev": true,
       "requires": {
@@ -5968,7 +5968,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "http://npm.prod.hulu.com/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
@@ -5977,13 +5977,13 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://npm.prod.hulu.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://npm.prod.hulu.com/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.com/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
@@ -6000,7 +6000,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -6010,7 +6010,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://npm.prod.hulu.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.com/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -6021,7 +6021,7 @@
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "resolved": "http://npm.prod.hulu.com/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
@@ -6030,19 +6030,19 @@
     },
     "stream-consume": {
       "version": "0.1.1",
-      "resolved": "http://npm.prod.hulu.com/stream-consume/-/stream-consume-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/stream-consume/-/stream-consume-0.1.1.tgz",
       "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
       "dev": true
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://npm.prod.hulu.com/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.com/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://npm.prod.hulu.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -6051,7 +6051,7 @@
     },
     "strip-bom": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/strip-bom/-/strip-bom-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/strip-bom/-/strip-bom-1.0.0.tgz",
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "dev": true,
       "requires": {
@@ -6061,7 +6061,7 @@
     },
     "strip-indent": {
       "version": "1.0.1",
-      "resolved": "http://npm.prod.hulu.com/strip-indent/-/strip-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
@@ -6070,19 +6070,19 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "http://npm.prod.hulu.com/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
-      "resolved": "http://npm.prod.hulu.com/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.com/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
     "temp": {
       "version": "0.8.3",
-      "resolved": "http://npm.prod.hulu.com/temp/-/temp-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.com/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
@@ -6092,7 +6092,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://npm.prod.hulu.com/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.com/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -6100,13 +6100,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://npm.prod.hulu.com/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.com/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "http://npm.prod.hulu.com/through2/-/through2-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.com/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
@@ -6116,13 +6116,13 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -6137,7 +6137,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://npm.prod.hulu.com/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.com/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -6148,7 +6148,7 @@
     },
     "tildify": {
       "version": "1.2.0",
-      "resolved": "http://npm.prod.hulu.com/tildify/-/tildify-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.com/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
@@ -6157,13 +6157,13 @@
     },
     "time-stamp": {
       "version": "1.1.0",
-      "resolved": "http://npm.prod.hulu.com/time-stamp/-/time-stamp-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/time-stamp/-/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "http://npm.prod.hulu.com/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.com/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -6172,7 +6172,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://npm.prod.hulu.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.com/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6183,7 +6183,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "http://npm.prod.hulu.com/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
@@ -6195,7 +6195,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "http://npm.prod.hulu.com/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -6205,7 +6205,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "http://npm.prod.hulu.com/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.com/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
@@ -6215,19 +6215,19 @@
     },
     "tr46": {
       "version": "0.0.3",
-      "resolved": "http://npm.prod.hulu.com/tr46/-/tr46-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.com/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "http://npm.prod.hulu.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -6236,13 +6236,13 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://npm.prod.hulu.com/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.com/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://npm.prod.hulu.com/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.com/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -6251,7 +6251,7 @@
     },
     "type-detect": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/type-detect/-/type-detect-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
@@ -6281,25 +6281,25 @@
     },
     "unc-path-regex": {
       "version": "0.1.2",
-      "resolved": "http://npm.prod.hulu.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "underscore": {
       "version": "1.7.0",
-      "resolved": "http://npm.prod.hulu.com/underscore/-/underscore-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.com/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "underscore.string": {
       "version": "2.4.0",
-      "resolved": "http://npm.prod.hulu.com/underscore.string/-/underscore.string-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.com/underscore.string/-/underscore.string-2.4.0.tgz",
       "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
       "dev": true
     },
     "union-value": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/union-value/-/union-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
@@ -6311,7 +6311,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://npm.prod.hulu.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -6320,7 +6320,7 @@
         },
         "set-value": {
           "version": "0.4.3",
-          "resolved": "http://npm.prod.hulu.com/set-value/-/set-value-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.com/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
@@ -6334,13 +6334,13 @@
     },
     "unique-stream": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/unique-stream/-/unique-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
       "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "http://npm.prod.hulu.com/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.com/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -6350,7 +6350,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "http://npm.prod.hulu.com/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.com/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -6361,7 +6361,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "http://npm.prod.hulu.com/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.com/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -6372,13 +6372,13 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "http://npm.prod.hulu.com/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.com/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://npm.prod.hulu.com/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.com/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
@@ -6386,7 +6386,7 @@
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "http://npm.prod.hulu.com/uri-js/-/uri-js-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.com/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
@@ -6395,25 +6395,25 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "http://npm.prod.hulu.com/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.com/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "http://npm.prod.hulu.com/use/-/use-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
     "user-home": {
       "version": "1.1.1",
-      "resolved": "http://npm.prod.hulu.com/user-home/-/user-home-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "http://npm.prod.hulu.com/util/-/util-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.com/util/-/util-0.11.1.tgz",
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
       "dev": true,
       "requires": {
@@ -6422,19 +6422,19 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "http://npm.prod.hulu.com/uuid/-/uuid-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.com/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "v8flags": {
       "version": "2.1.1",
-      "resolved": "http://npm.prod.hulu.com/v8flags/-/v8flags-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.com/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
@@ -6443,7 +6443,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "http://npm.prod.hulu.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
@@ -6453,7 +6453,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://npm.prod.hulu.com/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.com/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -6464,7 +6464,7 @@
     },
     "vinyl": {
       "version": "0.5.3",
-      "resolved": "http://npm.prod.hulu.com/vinyl/-/vinyl-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.com/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
@@ -6475,7 +6475,7 @@
     },
     "vinyl-fs": {
       "version": "0.3.14",
-      "resolved": "http://npm.prod.hulu.com/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "resolved": "https://registry.npmjs.com/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
@@ -6491,13 +6491,13 @@
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "resolved": "http://npm.prod.hulu.com/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.com/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://npm.prod.hulu.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.com/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -6509,7 +6509,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://npm.prod.hulu.com/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.com/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -6519,7 +6519,7 @@
         },
         "vinyl": {
           "version": "0.4.6",
-          "resolved": "http://npm.prod.hulu.com/vinyl/-/vinyl-0.4.6.tgz",
+          "resolved": "https://registry.npmjs.com/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
@@ -6531,7 +6531,7 @@
     },
     "vinyl-sourcemaps-apply": {
       "version": "0.2.1",
-      "resolved": "http://npm.prod.hulu.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
@@ -6540,13 +6540,13 @@
     },
     "webidl-conversions": {
       "version": "2.0.1",
-      "resolved": "http://npm.prod.hulu.com/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
       "integrity": "sha1-O/glj30xjHRDw28uFpQCoaZwNQY=",
       "dev": true
     },
     "whatwg-url-compat": {
       "version": "0.6.5",
-      "resolved": "http://npm.prod.hulu.com/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.com/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
       "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
       "dev": true,
       "requires": {
@@ -6555,7 +6555,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "http://npm.prod.hulu.com/which/-/which-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.com/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
@@ -6576,19 +6576,19 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://npm.prod.hulu.com/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.com/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "xml-name-validator": {
       "version": "2.0.1",
-      "resolved": "http://npm.prod.hulu.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "http://npm.prod.hulu.com/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.com/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },


### PR DESCRIPTION
Also adds a .npmrc to ensure the public registry is always used!

Everything still installs properly, so that's good.  Previously, dependencies wouldn't be installable for anyone else!