### PR TITLE
expose addComputedDependency so computeds can change their dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3921,7 +3921,8 @@
                 "console-control-strings": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "gauge": {
                   "version": "2.6.0",
@@ -3962,6 +3963,7 @@
                       "version": "1.0.2",
                       "bundled": true,
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3972,6 +3974,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
                           },
@@ -3979,7 +3982,8 @@
                             "number-is-nan": {
                               "version": "1.0.0",
                               "bundled": true,
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
@@ -3987,6 +3991,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
                           },
@@ -3994,7 +3999,8 @@
                             "number-is-nan": {
                               "version": "1.0.0",
                               "bundled": true,
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A MVVM data binding framework designed for speed and efficiency on living room devices",
   "author": "Hulu Living Room",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A MVVM data binding framework designed for speed and efficiency on living room devices",
   "author": "Hulu Living Room",
   "scripts": {

--- a/src/base/observables.coffee
+++ b/src/base/observables.coffee
@@ -235,6 +235,7 @@ qdInternal.observables = {
         obs.isBound = @hasDependencies
         obs.immediate = @helpers.immediate
         obs.silent = @helpers.silent
+        obs.addComputedDependency = @addComputedDependency
 
         # since not can be passed alone in a binding string we
         # need to pass a closure, this will be removed once not


### PR DESCRIPTION
I'm in a situation where i have a computed observable that depends on a dynamic list of other observables (things can be added to the list throughout the lifetime of the computed). I order to support that i need access to the addComputedDependency function, which i can use as is without any changes.