### PR TITLE
Node events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/quickdraw",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A MVVM data binding framework designed for speed and efficiency on living room devices",
   "author": "Hulu Living Room",
   "scripts": {

--- a/src/bindings/event.coffee
+++ b/src/bindings/event.coffee
@@ -59,6 +59,7 @@ dispatchEvent = (event) ->
         event.stopPropagation()
 
         context = @context.get(currentTarget)
+
         # run the callback, look for explicit truth return
         unless callback(context, event) is true
             # cancel the default event action
@@ -79,11 +80,11 @@ registerGlobalHandler = (node, eventName, callback) ->
         globalRegistry[eventName] = (event) => dispatchEvent.call(@, event)
         document.addEventListener(eventName, globalRegistry[eventName], true)
 
-        # store callback on this node for event
-        node.setValue(eventName, callback)
-
         # store the global registry on the document
         @storage.setValue(document, 'registry', globalRegistry)
+
+    # store callback on this node for event
+    node.setValue(eventName, callback)
 
     return
 
@@ -122,11 +123,14 @@ initialize = (bindingData, node) ->
 
     return
 
-cleanup = (bindingData, node) ->
+cleanup = (node) ->
     registry = @storage.getValue(node, 'registry') ? {}
 
     for eventName, binding of registry
         node.setValue(eventName, null)
         node.removeEventListener(eventName, binding)
+        delete registry[eventName]
+
+    @storage.setValue(node, 'registry', registry)
 
 qd.registerBindingHandler(HANDLER_NAME, { initialize, cleanup })

--- a/src/bindings/event.coffee
+++ b/src/bindings/event.coffee
@@ -1,28 +1,56 @@
 # Quickdraw Handler - Event Listeners
-# 
+#
 # Registration Name: event
-# 
+#
 # Description:
-#   Enables listening for specified events on specified nodes. Unlike normal listening
-#   each DOM node does not have listeners attached and instead only singular global
-#   listeners are registered for performance.
-#   
-#   When events are dispatched the callback supplied through the binding string is given
-#   the original binding context and the original DOM event that triggered the callback.
-#   
+#   Enables listening for specified events on nodes. There are two forms of this
+#   binding which work slightly differently:
+#
+#   The default form takes a map of event types to handler functions. Unlike
+#   normal listening each DOM node does not have listeners attached and instead
+#   only singular global listeners are registered on the document For backwards
+#   compatibility reasons these handlers use the capture phase of the event
+#   lifecycle and stop event propogation when events occur.
+#
+#   In the second form a map of event types to objects should be provided. Each
+#   object should contain a `handler` key which will be invoked when the event
+#   occurs. In this case the event handler is attached to individual DOM nodes
+#   rather than to the parent document, and the bubbling phase is used for event
+#   handling.
+#
+#   When events are dispatched the callback supplied through the binding string
+#   is given the original binding context and the original DOM event that
+#   triggered the callback.
+#
 # Handles Child Node Bindings: No
-# 
+#
 # Possible Binding Data:
 #   [Object]     A javascript object where the keys are event names and the values
 #                are callbacks that should be executed when the event occurs with
-#                the corresponding DOM node as a target.
+#                the corresponding DOM node as a target. If attaching the event
+#                listener to the node itself and skipping the capture phase is
+#                desired, the value of the object should instead be an object with
+#                `useCapture` and `callback` keys
+#
+# Examples:
+#   // event listener hoisted to document and capture phase is used
+#   event: { click: onClick }
+#
+#   // event listener attached to node and bubbling phase is used
+#   event: { click: { handler: onClick } }
+#
+#   // mixture of both strategies
+#   event: { click: onClick, blur: { handler: onBlur } }
+
+HANDLER_NAME = 'event'
+
 dispatchEvent = (event) ->
     # start at the event target and work our way up
     currentTarget = event.target
     eventName = event.type
     callback = null
     while currentTarget? and not callback?
-        callback = @storage.getValue(currentTarget, eventName, 'event')
+        callback = @storage.getValue(currentTarget, eventName, HANDLER_NAME)
         unless callback?
             currentTarget = currentTarget.parentElement
 
@@ -36,36 +64,69 @@ dispatchEvent = (event) ->
             # cancel the default event action
             event.preventDefault()
 
-    # dont capture loop results
     return true
 
+###*
+# Registers an event listener on the document which will intercept events during
+# the capture phase
+###
+registerGlobalHandler = (node, eventName, callback) ->
+    document = node.getProperty('ownerDocument')
+    globalRegistry = @storage.getValue(document, 'registry') ? {}
 
-qd.registerBindingHandler('event', {
-    initialize : (bindingData, node) ->
-        # get the owning document for our global event references
-        document = node.getProperty('ownerDocument')
-        globalRegistry = @storage.getValue(document, 'registry') ? {}
+    # ensure we have registered for the event on this document
+    unless globalRegistry[eventName]?
+        globalRegistry[eventName] = (event) => dispatchEvent.call(@, event)
+        document.addEventListener(eventName, globalRegistry[eventName], true)
 
-        for own eventName, callback of bindingData
-            continue unless callback?
-
-            # ensure we have globally registered for the event on this document
-            unless globalRegistry[eventName]?
-                globalRegistry[eventName] = (event) => dispatchEvent.call(@, event)
-                document.addEventListener(eventName, globalRegistry[eventName], true)
-
-            # store callback on this node for event
-            node.setValue(eventName, callback)
+        # store callback on this node for event
+        node.setValue(eventName, callback)
 
         # store the global registry on the document
         @storage.setValue(document, 'registry', globalRegistry)
 
-        # events should always have access to the binding context but that wont
-        # be set if the element is just a simple element, so we do it manually
-        # just in case there is no dynamic data
-        if @state.current.model?
-            @context.set(node, @state.current.model)
+    return
 
-        # dont capture results of loops
-        return
-})
+###*
+# Registers an event listener on the bound DOM node which will respond to events
+# during the bubble phase
+###
+registerLocalHandler = (node, eventName, callback) ->
+    eventRegistry = @storage.getValue(node, 'registry') ? {}
+
+    unless eventRegistry[eventName]?
+        eventRegistry[eventName] = (event) => dispatchEvent.call(@, event)
+        node.addEventListener(eventName, eventRegistry[eventName])
+        node.setValue(eventName, callback)
+
+        @storage.setValue(node, 'registry', eventRegistry)
+
+    return
+
+initialize = (bindingData, node) ->
+    for own eventName, binding of bindingData
+        continue unless binding?
+
+        if typeof binding is 'function'
+            handler = binding
+            registerGlobalHandler.call(@, node, eventName, handler)
+        else
+            { handler } = binding
+            registerLocalHandler.call(@, node, eventName, handler)
+
+    # events should always have access to the binding context but that wont
+    # be set if the element is just a simple element, so we do it manually
+    # just in case there is no dynamic data
+    if @state.current.model?
+        @context.set(node, @state.current.model)
+
+    return
+
+cleanup = (bindingData, node) ->
+    registry = @storage.getValue(node, 'registry') ? {}
+
+    for eventName, binding of registry
+        node.setValue(eventName, null)
+        node.removeEventListener(eventName, binding)
+
+qd.registerBindingHandler(HANDLER_NAME, { initialize, cleanup })

--- a/src/bindings/event.coffee
+++ b/src/bindings/event.coffee
@@ -8,7 +8,7 @@
 #
 #   The default form takes a map of event types to handler functions. Unlike
 #   normal listening each DOM node does not have listeners attached and instead
-#   only singular global listeners are registered on the document For backwards
+#   only singular global listeners are registered on the document. For backwards
 #   compatibility reasons these handlers use the capture phase of the event
 #   lifecycle and stop event propogation when events occur.
 #

--- a/test/bindings/event.coffee
+++ b/test/bindings/event.coffee
@@ -1,4 +1,5 @@
 describe("Quickdraw.Bindings.Event", ->
+
     prepClick = ->
         event = sandbox.document.createEvent("MouseEvents")
         event.initMouseEvent("click", true, true)
@@ -10,67 +11,129 @@ describe("Quickdraw.Bindings.Event", ->
 
     it("Handler is bound to event keyword", assertModuleBound("event"))
 
-    it("Events are registered on parent document instead of node", ->
-        node = createVirtualElement('div')
-        node.addEventListener = sinon.stub()
-        data = { click : sinon.stub() }
+    describe('global event listeners', ->
 
-        callback = qdGetInitialize("event")
-        callback(data, node)
+        it("Events are registered on parent document instead of node", ->
+            node = createVirtualElement('div')
+            node.addEventListener = sinon.stub()
+            data = { click : sinon.stub() }
 
-        assert.isFalse(node.addEventListener.called, "Should not have added listener to node")
-        assert.isTrue(sandbox.document.addEventListener.calledWith('click'), "Should have registered click on body")
+            callback = qdGetInitialize("event")
+            callback(data, node)
 
-        assert.equal(node.getValue('click', 'event'), data.click, "Should have stored the click callback in the node storage")
+            assert.isFalse(node.addEventListener.called, "Should not have added listener to node")
+            assert.isTrue(sandbox.document.addEventListener.calledWith('click'), "Should have registered click on body")
+
+            assert.equal(node.getValue('click', 'event'), data.click, "Should have stored the click callback in the node storage")
+        )
+
+        it("Events are only registered for once", ->
+            node = createVirtualElement('div')
+            sandbox.qd._.storage.setValue(sandbox.document, 'registry', {
+                click : sinon.stub()
+            }, 'event')
+            data = { click : sinon.stub() }
+
+            callback = qdGetInitialize("event")
+            callback(data, node)
+
+            assert.isFalse(sandbox.document.addEventListener.called, "Should not have called add event, already registered")
+        )
+
+        it("Events properly trigger their callbacks", ->
+            node = createVirtualElement('div')
+            data = { click : sinon.stub() }
+
+            callback = qdGetInitialize("event")
+            callback(data, node)
+
+            clickEvent = prepClick()
+            # call dispatch so target set correctly, but jsdom does not properly model events
+            node.getRawNode().dispatchEvent(clickEvent)
+            sinon.spy(clickEvent, 'preventDefault')
+
+            # call into our global handler that would properly
+            dispatchEvent = sandbox.document.addEventListener.firstCall.args[1]
+            dispatchEvent(clickEvent)
+
+            assert.isTrue(data.click.called, "Should have called callback for event")
+            assert.isTrue(clickEvent.preventDefault.called, 'Should prevent default by default')
+        )
+
+        it("Default can be explicitly allowed by event", ->
+            node = createVirtualElement('div')
+            data = { click : sinon.spy(-> return true) }
+
+            callback = qdGetInitialize("event")
+            callback(data, node)
+
+            clickEvent = prepClick()
+            node.getRawNode().dispatchEvent(clickEvent)
+            sinon.spy(clickEvent, 'preventDefault')
+
+            dispatchEvent = sandbox.document.addEventListener.firstCall.args[1]
+            dispatchEvent(clickEvent)
+
+            assert.isFalse(clickEvent.preventDefault.called, "Should not have prevented default")
+        )
     )
 
-    it("Events are only registered for once", ->
-        node = createVirtualElement('div')
-        sandbox.qd._.storage.setValue(sandbox.document, 'registry', {
-            click : sinon.stub()
-        }, 'event')
-        data = { click : sinon.stub() }
+    describe("Raw event listeners", ->
+        it("Events are registered on the node instead of the parent document", ->
+            node = createVirtualElement("div")
+            node.addEventListener = sinon.spy()
+            data = { click : { handler : sinon.spy() } }
 
-        callback = qdGetInitialize("event")
-        callback(data, node)
+            callback = qdGetInitialize("event")
+            callback(data, node)
 
-        assert.isFalse(sandbox.document.addEventListener.called, "Should not have called add event, already registered")
-    )
+            assert.isTrue(node.addEventListener.called, "should have added listener to node")
+            assert.isFalse(sandbox.document.addEventListener.calledWith('click'), "Should not have registered click on body")
 
-    it("Events properly trigger their callbacks", ->
-        node = createVirtualElement('div')
-        data = { click : sinon.stub() }
+            assert.equal(node.getValue('click', 'event'), data.click.handler, "Should have stored the click callback in the node storage")
+        )
 
-        callback = qdGetInitialize("event")
-        callback(data, node)
+        it("Events properly trigger their callbacks", ->
+            node = createVirtualElement('div')
+            sinon.spy(node, 'addEventListener')
+            data = {
+                click : { handler : sinon.spy() }
+            }
 
-        clickEvent = prepClick()
-        # call dispatch so target set correctly, but jsdom does not properly model events
-        node.getRawNode().dispatchEvent(clickEvent)
-        sinon.spy(clickEvent, 'preventDefault')
+            callback = qdGetInitialize("event")
+            callback(data, node)
 
-        # call into our global handler that would properly 
-        dispatchEvent = sandbox.document.addEventListener.firstCall.args[1]
-        dispatchEvent(clickEvent)
+            clickEvent = prepClick()
+            # call dispatch so target set correctly, but jsdom does not properly model events
+            node.getRawNode().dispatchEvent(clickEvent)
+            sinon.spy(clickEvent, 'preventDefault')
 
-        assert.isTrue(data.click.called, "Should have called callback for event")
-        assert.isTrue(clickEvent.preventDefault.called, 'Should prevent default by default')
-    )
+            # call into our global handler that would properly
+            dispatchEvent = node.addEventListener.firstCall.args[1]
+            dispatchEvent(clickEvent)
 
-    it("Default can be explicitly allowed by event", ->
-        node = createVirtualElement('div')
-        data = { click : sinon.spy(-> return true) }
+            assert.isTrue(data.click.handler.called, "Should have called callback for event")
+            assert.isTrue(clickEvent.preventDefault.called, 'Should prevent default by default')
+        )
 
-        callback = qdGetInitialize("event")
-        callback(data, node)
+        it("Default can be explicitly allowed by event", ->
+            node = createVirtualElement('div')
+            node.addEventListener = sinon.spy()
+            data = {
+                click : { handler : sinon.spy(-> return true) }
+            }
 
-        clickEvent = prepClick()
-        node.getRawNode().dispatchEvent(clickEvent)
-        sinon.spy(clickEvent, 'preventDefault')
+            callback = qdGetInitialize("event")
+            callback(data, node)
 
-        dispatchEvent = sandbox.document.addEventListener.firstCall.args[1]
-        dispatchEvent(clickEvent)
+            clickEvent = prepClick()
+            node.getRawNode().dispatchEvent(clickEvent)
+            sinon.spy(clickEvent, 'preventDefault')
 
-        assert.isFalse(clickEvent.preventDefault.called, "Should not have prevented default")
+            dispatchEvent = node.addEventListener.firstCall.args[1]
+            dispatchEvent(clickEvent)
+
+            assert.isFalse(clickEvent.preventDefault.called, "Should not have prevented default")
+        )
     )
 )


### PR DESCRIPTION
Currently the Quickdraw `event` binding handler makes a few decisions for us:

1. It uses the capture phase of the event lifecycle, so it runs before handlers which use the bubbling phase
2. It attaches event handlers to `document`, the hightest node in the DOM tree, and
3. It stops propogation as soon as a handler is found

These things together mean that if two elements on a page are listening for the same event (say, `click` for example), only the first one to register an event handler will ever be invoked. This is additionally problematic if you have components which want to use the bubbling phase because by this time Quickdraw has already finished routing and handling any events which may have been dispatched.

This PR expands the syntax of the `event` binding handler to allow for "raw events". These events do not use the capture phase and are attached to the DOM nodes that they are specified on, not at the document level. The existing binding handler syntax is left unchanged.

So, this will still work in a template:

```html
<div data-bind="event: { click: onClick }"></div>
```

But with the new syntax you can also do this:

```html
<div data-bind="event: { click: { handler: onClick } }"></div>
```

The object literal signals to the binding handler that we should use raw events. In the future additional options can be passed into the object literal (e.g. a flag to control whether or not the capture phase is used), but for now I don't need that functionality so I'll leave it with a minimal feature set for now.